### PR TITLE
bug fixed: hide the menu when page is still loading

### DIFF
--- a/css/jside-menu.css
+++ b/css/jside-menu.css
@@ -28,7 +28,9 @@
    --skin-hover: #ddd; 
    --skin-color:  #232323;
 }
-
+.menu-body.visibility{
+  visibility: hidden;
+}
 .menubar{
    width: 100%;
    height: 48px;

--- a/index.html
+++ b/index.html
@@ -30,6 +30,7 @@
            <a href="#1"><img src="img/jside-menu.png" alt="jSide Menu" /> </a>
      </menuitem>
 </menu>
+<div class="menu-body visibility">
 <div class="menu-head">
    <span class="layer">
 <div class="col">
@@ -74,6 +75,7 @@
 <li> <a href="#1"> <i class="material-icons">format_size</i>  Main item six </a></li> 
 </ul>
 </nav>
+</div>
 <!--End jSide Menu-->
 
 

--- a/js/jquery.jside.menu.js
+++ b/js/jquery.jside.menu.js
@@ -68,6 +68,7 @@ $(dHeading).click(function(){
 $(menuTrigger).click(function(){
    $(jSide).toggleClass("open");
    $(dimBackground).show(setting.jSideTransition);
+   $(".menu-body").removeClass("visibility");
 });
 
 //close menu if user click outside of it
@@ -81,6 +82,7 @@ $(menuTrigger).click(function(){
     if (!$(jSide).hasClass("open")) {
      $(dimBackground).hide(setting.jSideTransition);
         }
+ $(".menu-body").addClass("visibility");
       });
    });
  };


### PR DESCRIPTION
I have improved the menu's appearance when the page is under loading.